### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/crypto-api-tests.cabal
+++ b/crypto-api-tests.cabal
@@ -16,7 +16,7 @@ homepage:       http://trac.haskell.org/crypto-api/wiki
 bug-reports:    http://trac.haskell.org/crypto-api/report/1
 stability:      stable
 build-type:     Simple
-cabal-version:  >= 1.6
+cabal-version:  >= 1.8
 tested-with:    GHC == 6.12.1
 data-files:
          Test/KAT_AES/*.txt


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: crypto-api-tests.cabal:34:30: version operators used. To use version                                                                                                                                                                                                      
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```